### PR TITLE
fix: mobile responsiveness pass across all homepage sections

### DIFF
--- a/src/app/components/banner/DynamicBanner.module.css
+++ b/src/app/components/banner/DynamicBanner.module.css
@@ -70,11 +70,13 @@
 
 @media (max-width: 768px) {
   .banner {
-    padding: 4rem 1.5rem;
+    padding: 3rem 1.5rem;
+    align-items: stretch;
   }
 
   .cta {
     width: 100%;
+    justify-content: center;
     text-align: center;
   }
 }

--- a/src/app/components/circularTestimonials/CircularTestimonials.tsx
+++ b/src/app/components/circularTestimonials/CircularTestimonials.tsx
@@ -271,6 +271,8 @@ export const CircularTestimonials = ({
           height: 20rem;
           -webkit-perspective: 1000px;
           perspective: 1000px;
+          overflow: hidden;
+          border-radius: 1.25rem;
         }
         .ct-image {
           position: absolute;

--- a/src/app/components/footer/Footer.tsx
+++ b/src/app/components/footer/Footer.tsx
@@ -55,11 +55,6 @@ export default function Footer() {
             <li>
               <span>Bethlehem, Free State</span>
             </li>
-            <li>
-              <span>
-                <link></link>
-              </span>
-            </li>
           </ul>
         </div>
       </div>

--- a/src/app/components/hero/Hero.module.css
+++ b/src/app/components/hero/Hero.module.css
@@ -191,24 +191,37 @@
   }
 
   .actions {
-    justify-content: flex-start;
+    flex-wrap: wrap;
+    justify-content: center;
+    overflow-x: unset;
+    padding-bottom: 0;
   }
 
   .primaryButton,
   .secondaryButton {
-    min-width: 130px;
+    min-width: 140px;
+    flex: 1 1 140px;
   }
 
   .stats {
-    grid-template-columns: repeat(3, minmax(160px, 1fr));
-    overflow-x: auto;
-    scroll-snap-type: x mandatory;
-    padding-bottom: 0.5rem;
+    grid-template-columns: repeat(2, 1fr);
+    overflow-x: unset;
+    scroll-snap-type: unset;
+    padding-bottom: 0;
+    gap: 0.75rem;
     width: 100%;
   }
 
   .statItem {
-    scroll-snap-align: start;
-    min-width: 160px;
+    scroll-snap-align: unset;
+    min-width: 0;
+  }
+
+  .statValue {
+    font-size: 1.25rem;
+  }
+
+  .statLabel {
+    font-size: 0.8rem;
   }
 }

--- a/src/app/components/navbar/Navbar.tsx
+++ b/src/app/components/navbar/Navbar.tsx
@@ -108,7 +108,12 @@ export default function Navbar() {
             const isBookNow = navItem.path === routes.bookNow.path;
             if (isBookNow) {
               return (
-                <ProtectedLink key={navItem.path} href={navItem.path} className={styles.navLink}>
+                <ProtectedLink
+                  key={navItem.path}
+                  href={navItem.path}
+                  className={styles.navLink}
+                  onClick={() => setMenuOpen(false)}
+                >
                   {navItem.label}
                 </ProtectedLink>
               );

--- a/src/app/components/protected/ProtectedLink.tsx
+++ b/src/app/components/protected/ProtectedLink.tsx
@@ -9,16 +9,19 @@ export function ProtectedLink({
   href,
   children,
   className,
+  onClick,
 }: {
   href: string;
   children: React.ReactNode;
   className?: string;
+  onClick?: () => void;
 }) {
   const { user } = useAuth();
   const router = useRouter();
   const pathname = usePathname();
 
   const handleClick = (e: React.MouseEvent) => {
+    onClick?.();
     if (!user) {
       e.preventDefault();
       router.push('/login?next=' + encodeURIComponent(pathname ?? '/'));
@@ -27,13 +30,11 @@ export function ProtectedLink({
 
   if (user)
     return (
-      <Link href={href} className={className}>
+      <Link href={href} className={className} onClick={onClick}>
         {children}
       </Link>
     );
   return (
-    // Render a link that intercepts clicks when not authenticated
-
     <a href={href} onClick={handleClick} className={className}>
       {children}
     </a>

--- a/src/app/features/loyalty/Loyalty.module.css
+++ b/src/app/features/loyalty/Loyalty.module.css
@@ -22,6 +22,7 @@
 }
 
 .title {
+  font-size: clamp(2.25rem, 5vw, 3.5rem);
   font-weight: 700;
   font-family: var(--font-playfair-display), serif;
   line-height: 1;
@@ -137,6 +138,22 @@
   opacity: 0.85;
 }
 
+@media (max-width: 900px) {
+  .page {
+    padding: 3.5rem 2.5rem;
+  }
+
+  .grid {
+    flex-wrap: wrap;
+    gap: 1.25rem;
+  }
+
+  .card {
+    flex: 1 1 calc(50% - 0.625rem);
+    min-width: 0;
+  }
+}
+
 @media (max-width: 768px) {
   .page {
     padding: 3rem 1.5rem;
@@ -149,9 +166,23 @@
 
   .grid {
     flex-direction: column;
+    flex-wrap: nowrap;
+    gap: 1rem;
   }
 
   .card {
+    flex: none;
+    width: 100%;
     min-height: 120px;
+  }
+}
+
+@media (max-width: 480px) {
+  .page {
+    padding: 2.5rem 1.25rem;
+  }
+
+  .tier {
+    font-size: 1.5rem;
   }
 }

--- a/src/app/features/servicesSection/ServiceSection.module.css
+++ b/src/app/features/servicesSection/ServiceSection.module.css
@@ -41,7 +41,7 @@
 }
 
 .services {
-  width: 100vw;
+  width: 100%;
   margin: 0 auto;
   padding: var(--space-9);
   display: flex;
@@ -175,6 +175,10 @@
 }
 
 @media (max-width: 900px) {
+  .services {
+    padding: 4rem 2.5rem;
+  }
+
   .content {
     grid-template-columns: 1fr;
   }
@@ -186,7 +190,7 @@
 
 @media (max-width: 600px) {
   .services {
-    padding: var(--space-5);
+    padding: 2.5rem 1.25rem;
   }
 
   .header {


### PR DESCRIPTION
hero:
- stats: replace 3-col horizontal scroll with 2-col grid so 3rd stat wraps below instead of clipping off-screen on 375px viewports
- actions: allow flex-wrap so buttons stack on very narrow screens

services:
- fix width:100vw → width:100% to prevent scrollbar-width overflow
- add 900px padding breakpoint (4rem 2.5rem) and tighten 600px to (2.5rem 1.25rem) — was only reducing from 7rem at 600px

loyalty:
- add explicit clamp font-size to title (was inheriting h1 browser default)
- add 900px breakpoint: 2×2 flex-wrap grid so 4 cards don't crush to ~61px content width on tablets
- add 480px breakpoint for tighter mobile padding and smaller tier font

circular testimonials:
- add overflow:hidden + border-radius to image wrap so side images are clipped instead of sticking 60px outside the container

banner:
- align-items:stretch at mobile so motion.div wrapper fills full width, making width:100% on the cta link actually take effect

navbar + protected-link:
- add optional onClick prop to ProtectedLink
- pass onClick={() => setMenuOpen(false)} to Book Now nav item so the mobile menu closes when tapping protected links

footer:
- remove invalid bare <link></link> element from contact column